### PR TITLE
Add auto-author-assign workflow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,13 @@
+name: Auto Author Assign
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.0.0


### PR DESCRIPTION
## Change

Automatically assign the pull request author as an assignee.

## Problem / Why

Not clear who is working on open PRs.

## References

- https://workday-dev.slack.com/archives/C01SZLCNHRT/p1701091864195409
