### PR TITLE
Use GH client to fetch current PR title

### DIFF
--- a/.github/workflows/jira-pr-title.yml
+++ b/.github/workflows/jira-pr-title.yml
@@ -1,7 +1,7 @@
 name: "Jira PR Title Check"
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
 jobs:
   check-title:
     runs-on: ubuntu-latest
@@ -11,10 +11,15 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const payload = context.payload
-          const prTitle = payload.pull_request.title
+          const { data } = await github.request("GET /repos/{owner}/{repo}/pulls/{pr}", {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pr: context.payload.pull_request.number
+          });
+
+          const prTitle = data.title
+
           const jiraPattern = /[A-Z]+-\d+/g
           if (!jiraPattern.test(prTitle)) {
-            console.log(`Cannot find a JIRA ticket in the PR title "${prTitle}"`)
             core.setFailed('Cannot find a JIRA ticket in the PR title')
           }


### PR DESCRIPTION

## Problem / Why

This way we get the latest PR title so if it has been changed we can re-run the action

## References

- https://jira2.workday.com/browse/PEAKONPE-4329