### PR TITLE
PEAKONPE-4329 Add Jira workflow retry and log IP

### DIFF
--- a/.github/workflows/jira-pr-title.yml
+++ b/.github/workflows/jira-pr-title.yml
@@ -10,12 +10,20 @@ jobs:
       uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        retries: 3
         script: |
-          const { data } = await github.request("GET /repos/{owner}/{repo}/pulls/{pr}", {
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pr: context.payload.pull_request.number
-          });
+          try {
+            const { data } = await github.request('GET /repos/{owner}/{repo}/pulls/{pr}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pr: context.payload.pull_request.number
+            });
+          } catch (error) {
+            const result = await github.request('https://icanhazip.com')
+            console.log('IP Address: ', result)
+
+            throw error;
+          }
 
           const prTitle = data.title
 


### PR DESCRIPTION
## Change

Adds a retry to the GH API call and also logs the IP address on failure

## Problem / Why

This is to make the check more resilient and also logs IP info so we can check if we allow that runner IP CIDR

## References

- https://jira2.workday.com/browse/PEAKONPE-4329