### PR TITLE
Re-run JIRA title check when editing titles

### DIFF
--- a/.github/workflows/jira-pr-title.yml
+++ b/.github/workflows/jira-pr-title.yml
@@ -1,7 +1,7 @@
 name: "Jira PR Title Check"
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 jobs:
   check-title:
     runs-on: arc-runner-set


### PR DESCRIPTION
## Change

Re-run JIRA title check when editing the titles

## Problem / Why

Currently, if you edit the title, the JIRA title check doesn't seem to be re-run 
